### PR TITLE
fix: avoid checking on tabId to catch also workers requests

### DIFF
--- a/background.js
+++ b/background.js
@@ -167,9 +167,7 @@ const onBeforeRequestHandler = (details) => {
 
 chrome.webRequest.onBeforeRequest.addListener(
 	(details) => {
-		if (details.tabId > -1) {
-			onBeforeRequestHandler(details);
-		}
+		onBeforeRequestHandler(details);
 	},
 	{
 		urls: ['<all_urls>'],


### PR DESCRIPTION
The `details.tabId` is always set to `-1` when the request is sent from any worker (web-workers or service-workers).

I believe excluding the workers requests is a mistake as application may leverage especially service-workers for caching and other features.

https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRequest