### PR TITLE
Allow filtering events by event properties

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -118,9 +118,13 @@ connection.onMessage.addListener((msg) => {
 function filterEvents(keyPressedEvent) {
 	var filter = new RegExp(keyPressedEvent.target.value, 'gi');
 	var eventElements = document.getElementById('trackMessages').getElementsByClassName('eventTracked');
+
+
 	for(eventElement of eventElements) {
 		var eventName = eventElement.getElementsByClassName('eventName')[0].textContent;
-		if (eventName.match(filter)) {
+		var eventContent = eventElement.getElementsByClassName('eventContent')[0]?.textContent;
+
+		if (eventName.match(filter) || eventContent.match(filter)) {
 			eventElement.classList.remove('hidden');
 		} else {
 			eventElement.classList.add('hidden');


### PR DESCRIPTION
**Feature**: Add support for filtering by event properties.

**Overview**: This PR enhances the existing filter functionality by allowing users to filter events based on event properties in addition to event names. It is useful when multiple events share the same name but differ in their attributes. It eliminates the need to manually click on each event to view the event data.

**Why**: We frequently fire events with the same name but varying properties. Previously, filtering was limited to event names, requiring to click on each event to get detailed information. This PR resolves that issue by adding the ability to filter by event properties, making it easier to locate specific data.